### PR TITLE
Fix locket lock results in test

### DIFF
--- a/integration/locket_commands_test.go
+++ b/integration/locket_commands_test.go
@@ -101,6 +101,7 @@ var _ = Describe("Locket commands", func() {
 			Expect(resp.GetResource()).To(Equal(&models.Resource{
 				Key:      "test-key",
 				Owner:    "test-owner",
+				Type:     "lock",
 				TypeCode: models.LOCK,
 			}))
 		})


### PR DESCRIPTION
### What is this change about?

- Follow up to PR:
  - https://github.com/cloudfoundry/cfdot/pull/11

tl;dr; the resources returned from locket will still contain a `Type: "lock"` field, but to create the resources, you must only specify a TypeCode.
  - It must essentially match this locket test: https://github.com/cloudfoundry/locket/compare/e0b7033ef7528d6a946d0a4b04d9e6882efcb4cb...a90299e1f75dadf2c8ce9f197b7b62ddc6924415#diff-fe4d1c46f9e48a2f9db22828f37c3fe03441e794663092b2c776052b9eb4fc51L432-R433

### What problem it is trying to solve?

Should resolve:
```
 [FAILED] Expected
      <*models.Resource | 0xc0006c6230>: {Key: "test-key", Owner: "test-owner", Value: "", Type: "lock", TypeCode: 1}
  to equal
      <*models.Resource | 0xc0006c6280>: {Key: "test-key", Owner: "test-owner", Value: "", Type: "", TypeCode: 1}
  In [It] at: /tmp/build/f7b1384f/repo/src/code.cloudfoundry.org/cfdot/integration/locket_commands_test.go:101 @ 03/14/24 22:17:00.772
```
Source: https://ci.funtime.lol/teams/wg-arp-diego/pipelines/diego-release/jobs/unit-and-integration-tests/builds/57#L65bb95ee:42:47

### What is the impact if the change is not made?

CI stays red! 

### How should this change be described in diego-release release notes?

N / A
