### PR TITLE
Change SetOutput to SetOut (deprecated, fails staticcheck)

### DIFF
--- a/commands/bbs_flags_test.go
+++ b/commands/bbs_flags_test.go
@@ -24,7 +24,7 @@ var _ = Describe("BBS Flags", func() {
 		}
 		commands.AddBBSFlags(dummyCmd)
 		output = gbytes.NewBuffer()
-		dummyCmd.SetOutput(output)
+		dummyCmd.SetOut(output)
 
 		validFlags = map[string]string{
 			"--bbsURL":         "https://example.com",

--- a/commands/locket_flags_test.go
+++ b/commands/locket_flags_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Locket Flags", func() {
 		}
 		commands.AddLocketFlags(dummyCmd)
 		output = gbytes.NewBuffer()
-		dummyCmd.SetOutput(output)
+		dummyCmd.SetOut(output)
 
 		validTLSFlags = map[string]string{
 			"--locketAPILocation": "127.0.0.1:9802",

--- a/commands/timeout_flag_test.go
+++ b/commands/timeout_flag_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Timeout Flag", func() {
 		}
 		commands.AddBBSAndTimeoutFlags(dummyCmd)
 		output = gbytes.NewBuffer()
-		dummyCmd.SetOutput(output)
+		dummyCmd.SetOut(output)
 
 		validFlags = map[string]string{
 			"--bbsURL":         "https://example.com",

--- a/commands/tls_flags_test.go
+++ b/commands/tls_flags_test.go
@@ -22,7 +22,7 @@ var _ = Describe("TLSFlags", func() {
 			Run: func(cmd *cobra.Command, args []string) {},
 		}
 		output = gbytes.NewBuffer()
-		dummyCmd.SetOutput(output)
+		dummyCmd.SetOut(output)
 
 		validTLSFlags = map[string]string{
 			"--clientCertFile": "fixtures/bbsClient.crt",


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Linter failing due to deprecation.  Cannot pass pipelines.


Backward Compatibility
---------------
Breaking Change? **No**
